### PR TITLE
Fix #5

### DIFF
--- a/scenes/Bootstrap/bootstrap.gd
+++ b/scenes/Bootstrap/bootstrap.gd
@@ -4,4 +4,4 @@ extends Node
 #you can use this scene to show your splashscreen
 
 func _ready():
-	SceneLoader.change_scene(RGT_Globals.main_menu_setting)
+	SceneLoader.change_scene(RGT_Globals.main_menu_setting, true, false)

--- a/scenes/LoadingScreen/LoadingScreen.gd
+++ b/scenes/LoadingScreen/LoadingScreen.gd
@@ -31,7 +31,7 @@ func _process(_delta):
 			if new_progress > progress_bar.value:
 				progress_bar.value = new_progress
 		ResourceLoader.THREAD_LOAD_LOADED:
-			if SceneLoader._wait_after_load:
+			if SceneLoader._force_wait_after_load:
 				progress_bar.value = progress_bar.max_value
 				status_label.text = LOADING_COMPLETE_TEXT
 				continue_label.text = CONTINUE_LABEL_TEXT


### PR DESCRIPTION
fix #5 

In SceneLoader to change_scene, change_scene_to_loading_screen and
change_scene_to_resource to not play the open transition
Rename _wait_after_load in _force_wait_after_load it is more
comprehensive